### PR TITLE
refactor: enhance `Container` component with `as` prop for better semantic markup

### DIFF
--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -1,10 +1,15 @@
 ---
-const { class: className } = Astro.props;
+interface Props {
+  tag?: keyof Pick<HTMLElementTagNameMap, 'div' | 'section' | 'article' | 'header' | 'footer' | 'code'>;
+  class?: string
+}
+
+const { tag: Tag = 'div', class: className } = Astro.props;
 ---
 
-<div class:list={[
+<Tag class:list={[
   'max-w-[40rem] mx-auto px-4',
   className,
 ]}>
   <slot />
-</div>
+</Tag>

--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -1,10 +1,10 @@
 ---
 interface Props {
-  tag?: keyof Pick<HTMLElementTagNameMap, 'div' | 'section' | 'article' | 'header' | 'footer' | 'code'>;
+  as: keyof Pick<HTMLElementTagNameMap, 'div' | 'section' | 'article' | 'header' | 'footer' | 'code'>;
   class?: string
 }
 
-const { tag: Tag = 'div', class: className } = Astro.props;
+const { as: Tag, class: className } = Astro.props;
 ---
 
 <Tag class:list={[

--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -1,10 +1,14 @@
 ---
-interface Props {
-  as: keyof Pick<HTMLElementTagNameMap, 'div' | 'section' | 'article' | 'header' | 'footer' | 'code'>;
-  class?: string
-}
+import type { Polymorphic } from 'astro/types';
 
-const { as: Tag, class: className } = Astro.props;
+type LayoutTag = 'section' | 'div' | 'article' | 'header' | 'footer' | 'code';
+
+type Props<Tag extends LayoutTag> = Polymorphic<{
+  as: Tag;
+  class?: string;
+}>;
+
+const { as: Tag = 'div', class: className } = Astro.props as Props<LayoutTag>;
 ---
 
 <Tag class:list={[

--- a/src/components/partials/Footer.astro
+++ b/src/components/partials/Footer.astro
@@ -2,10 +2,8 @@
 import Container from '@/components/Container.astro';
 ---
 
-<footer class="pt-24">
-  <Container>
-    <p class="text-center text-muted-foreground text-sm">
-      &copy; {new Date().getFullYear()}. Powered by <a href="https://astro.build" target="_blank" rel="noopener noreferrer">Astro</a> and CVfolio.
-    </p>
-  </Container>
-</footer>
+<Container tag='footer' class='pt-24'>
+  <p class="text-center text-muted-foreground text-sm">
+    &copy; {new Date().getFullYear()}. Powered by <a href="https://astro.build" target="_blank" rel="noopener noreferrer">Astro</a> and CVfolio.
+  </p>
+</Container>

--- a/src/components/partials/Footer.astro
+++ b/src/components/partials/Footer.astro
@@ -2,7 +2,7 @@
 import Container from '@/components/Container.astro';
 ---
 
-<Container tag='footer' class='pt-24'>
+<Container as='footer' class='pt-24'>
   <p class="text-center text-muted-foreground text-sm">
     &copy; {new Date().getFullYear()}. Powered by <a href="https://astro.build" target="_blank" rel="noopener noreferrer">Astro</a> and CVfolio.
   </p>

--- a/src/components/partials/Header.astro
+++ b/src/components/partials/Header.astro
@@ -8,27 +8,25 @@ const isWritingPage = pathname.startsWith('/writing');
 
 ---
 
-<header class="w-full">
-  <Container class="max-w-full flex justify-center items-center">
-    <div class="w-max fixed top-0 mt-5 bg-muted-foreground/40 backdrop-blur-md border border-border rounded-full p-1">
-      <nav class="flex items-center">
-        <ul class="flex items-center gap-1">
-          <li>
-            <a href="/" class:list={[
-              'font-medium transition-colors block px-5 py-2',
-              'hover:text-headings',
-              isHomePage && 'text-headings bg-muted-foreground/40 rounded-full',
-            ]}>Home</a>
-          </li>
-          <li>
-            <a href="/writing" class:list={[
-              'font-medium transition-colors block px-5 py-2',
-              'hover:text-headings',
-              isWritingPage && 'text-headings bg-muted-foreground/40 rounded-full',
-            ]}>Writing</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </Container>
-</header>
+<Container tag='header' class="w-full max-w-full flex justify-center items-center">
+  <div class="w-max fixed top-0 mt-5 bg-muted-foreground/40 backdrop-blur-md border border-border rounded-full p-1">
+    <nav class="flex items-center">
+      <ul class="flex items-center gap-1">
+        <li>
+          <a href="/" class:list={[
+            'font-medium transition-colors block px-5 py-2',
+            'hover:text-headings',
+            isHomePage && 'text-headings bg-muted-foreground/40 rounded-full',
+          ]}>Home</a>
+        </li>
+        <li>
+          <a href="/writing" class:list={[
+            'font-medium transition-colors block px-5 py-2',
+            'hover:text-headings',
+            isWritingPage && 'text-headings bg-muted-foreground/40 rounded-full',
+          ]}>Writing</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</Container>

--- a/src/components/partials/Header.astro
+++ b/src/components/partials/Header.astro
@@ -8,7 +8,7 @@ const isWritingPage = pathname.startsWith('/writing');
 
 ---
 
-<Container tag='header' class="w-full max-w-full flex justify-center items-center">
+<Container as='header' class="w-full max-w-full flex justify-center items-center">
   <div class="w-max fixed top-0 mt-5 bg-muted-foreground/40 backdrop-blur-md border border-border rounded-full p-1">
     <nav class="flex items-center">
       <ul class="flex items-center gap-1">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,11 +18,11 @@ const talks = await getCollection('talks');
 ---
 
 <BaseLayout seo={entry.data.seo}>
-  <Container tag='section' class='py-6'>
+  <Container as='section' class='py-6'>
     <Author {...DEFAULT_CONFIGURATION.author} />
   </Container>
 
-  <Container tag='section' class='py-6'>
+  <Container as='section' class='py-6'>
     <div class="flex flex-col gap-6">
       <div class="flex items-center">
         <span class="text-headings">About</span>
@@ -34,7 +34,7 @@ const talks = await getCollection('talks');
   </Container>
   {
     links.length > 0 && (
-      <Container tag='section' class='py-8'>
+      <Container as='section' class='py-8'>
         <div class="flex flex-col gap-5">
           <span class="text-headings">Contact</span>
           <ul class="flex flex-col gap-3">
@@ -62,7 +62,7 @@ const talks = await getCollection('talks');
   }
   {
     sortedJobs.length > 0 && (
-      <Container tag='section' class='py-6'>
+      <Container as='section' class='py-6'>
         <div class="flex flex-col gap-5">
           <span class="text-headings">Work Experience</span>
           <ul class="flex flex-col gap-8">
@@ -76,7 +76,7 @@ const talks = await getCollection('talks');
   }
   {
     talks.length > 0 && (
-      <Container tag='section' class='py-6'>
+      <Container as='section' class='py-6'>
         <div class="flex flex-col gap-5">
           <span class="text-headings">Speaking</span>
           <ul class="flex flex-col gap-8">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,83 +18,74 @@ const talks = await getCollection('talks');
 ---
 
 <BaseLayout seo={entry.data.seo}>
-  <section class="py-6">
-    <Container>
-      <Author {...DEFAULT_CONFIGURATION.author} />
-    </Container>
-  </section>
-  <section class="py-6">
-    <Container>
-      <div class="flex flex-col gap-6">
-        <div class="flex items-center">
-          <span class="text-headings">About</span>
-        </div>
-        <div class="prose dark:prose-invert">
-          <Content />
-        </div>
+  <Container tag='section' class='py-6'>
+    <Author {...DEFAULT_CONFIGURATION.author} />
+  </Container>
+
+  <Container tag='section' class='py-6'>
+    <div class="flex flex-col gap-6">
+      <div class="flex items-center">
+        <span class="text-headings">About</span>
       </div>
-    </Container>
-  </section>
+      <div class="prose dark:prose-invert">
+        <Content />
+      </div>
+    </div>
+  </Container>
   {
     links.length > 0 && (
-      <section class="py-8">
-        <Container>
-          <div class="flex flex-col gap-5">
-            <span class="text-headings">Contact</span>
-            <ul class="flex flex-col gap-3">
-              {links.map((link) => (
-                <li class="py-0.5">
-                  <div class="flex items-center gap-5">
-                    <span class="min-w-28 text-muted-foreground">
-                      {link.data.label}
-                    </span>
-                    <a
-                      class="text-headings font-medium"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                      href={link.data.url}
-                    >
-                      {link.data.name}
-                    </a>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </Container>
-      </section>
+      <Container tag='section' class='py-8'>
+        <div class="flex flex-col gap-5">
+          <span class="text-headings">Contact</span>
+          <ul class="flex flex-col gap-3">
+            {links.map((link) => (
+              <li class="py-0.5">
+                <div class="flex items-center gap-5">
+                  <span class="min-w-28 text-muted-foreground">
+                    {link.data.label}
+                  </span>
+                  <a
+                    class="text-headings font-medium"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    href={link.data.url}
+                  >
+                    {link.data.name}
+                  </a>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Container>
     )
   }
   {
     sortedJobs.length > 0 && (
-      <section class="py-6">
-        <Container>
-          <div class="flex flex-col gap-5">
-            <span class="text-headings">Work Experience</span>
-            <ul class="flex flex-col gap-8">
-              {sortedJobs.map((job) => (
-                <WorkExperience entry={job} />
-              ))}
-            </ul>
-          </div>
-        </Container>
-      </section>
+      <Container tag='section' class='py-6'>
+        <div class="flex flex-col gap-5">
+          <span class="text-headings">Work Experience</span>
+          <ul class="flex flex-col gap-8">
+            {sortedJobs.map((job) => (
+              <WorkExperience entry={job} />
+            ))}
+          </ul>
+        </div>
+      </Container>
     )
   }
   {
     talks.length > 0 && (
-      <section class="py-6">
-        <Container>
-          <div class="flex flex-col gap-5">
-            <span class="text-headings">Speaking</span>
-            <ul class="flex flex-col gap-8">
-              {talks.map((talk) => (
-                <Talk entry={talk} />
-              ))}
-            </ul>
-          </div>
-        </Container>
-      </section>
+      <Container tag='section' class='py-6'>
+        <div class="flex flex-col gap-5">
+          <span class="text-headings">Speaking</span>
+          <ul class="flex flex-col gap-8">
+            {talks.map((talk) => (
+              <Talk entry={talk} />
+            ))}
+          </ul>
+        </div>
+      </Container>
     )
   }
 </BaseLayout>

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -20,7 +20,7 @@ const { Content } = await render(entry);
 ---
 
 <BaseLayout seo={entry.data.seo}>
-  <Container tag='section'>
+  <Container as='section'>
     <article class="flex flex-col gap-6">
       <div class="flex flex-col gap-2">
         <a href="/writing" class="transition-all text-muted-foreground hover:text-foreground pb-4 text-sm w-max">

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -20,33 +20,31 @@ const { Content } = await render(entry);
 ---
 
 <BaseLayout seo={entry.data.seo}>
-  <section>
-    <Container>
-      <article class="flex flex-col gap-6">
-        <div class="flex flex-col gap-2">
-          <a href="/writing" class="transition-all text-muted-foreground hover:text-foreground pb-4 text-sm w-max">
-            Back to writing
-          </a>
-          <div class="flex flex-col gap-1.5">
-            <Avatar />
-            <span class="text-foreground">{DEFAULT_CONFIGURATION.author.name}</span>
-          </div>
-          <h1 class="text-3xl font-semibold text-headings">{entry.data.title}</h1>
+  <Container tag='section'>
+    <article class="flex flex-col gap-6">
+      <div class="flex flex-col gap-2">
+        <a href="/writing" class="transition-all text-muted-foreground hover:text-foreground pb-4 text-sm w-max">
+          Back to writing
+        </a>
+        <div class="flex flex-col gap-1.5">
+          <Avatar />
+          <span class="text-foreground">{DEFAULT_CONFIGURATION.author.name}</span>
         </div>
-        {entry.data.image && (
-          <div class="relative aspect-video overflow-hidden rounded-lg">
-            <Image
-              src={entry.data.image}
-              alt={entry.data.title}
-              class="object-cover"
-            />
-          </div>
-        )}
-        <div class="prose dark:prose-invert">
-          <Content />
+        <h1 class="text-3xl font-semibold text-headings">{entry.data.title}</h1>
+      </div>
+      {entry.data.image && (
+        <div class="relative aspect-video overflow-hidden rounded-lg">
+          <Image
+            src={entry.data.image}
+            alt={entry.data.title}
+            class="object-cover"
+          />
         </div>
-      </article>
-    </Container>
-  </section>
+      )}
+      <div class="prose dark:prose-invert">
+        <Content />
+      </div>
+    </article>
+  </Container>
 </BaseLayout>
   

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -11,10 +11,10 @@ const posts = await getCollection('posts');
 ---
 
 <BaseLayout seo={entry.data.seo}>
-  <Container tag='section' class='py-6'>
+  <Container as='section' class='py-6'>
     <Author {...DEFAULT_CONFIGURATION.author} />
   </Container>
-  <Container tag='section' class='py-6'>
+  <Container as='section' class='py-6'>
     <div class="flex flex-col gap-6">
       <span class="text-headings">Latest posts</span>
       <ul class="flex flex-col gap-3">

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -11,19 +11,15 @@ const posts = await getCollection('posts');
 ---
 
 <BaseLayout seo={entry.data.seo}>
-  <section class="py-6">
-    <Container>
-      <Author {...DEFAULT_CONFIGURATION.author} />
-    </Container>
-  </section>
-  <section class="py-6">
-    <Container>
-      <div class="flex flex-col gap-6">
-        <span class="text-headings">Latest posts</span>
-        <ul class="flex flex-col gap-3">
-          {posts.map((post) => <PostPreview entry={post} />)}
-        </ul>
-      </div>
-    </Container>
-  </section>
+  <Container tag='section' class='py-6'>
+    <Author {...DEFAULT_CONFIGURATION.author} />
+  </Container>
+  <Container tag='section' class='py-6'>
+    <div class="flex flex-col gap-6">
+      <span class="text-headings">Latest posts</span>
+      <ul class="flex flex-col gap-3">
+        {posts.map((post) => <PostPreview entry={post} />)}
+      </ul>
+    </div>
+  </Container>
 </BaseLayout>


### PR DESCRIPTION
# Refactor and Improvement of the Container Component

## Summary

* Enhances the flexibility of the Container component by requiring the `as` prop to specify semantic HTML tags, following the recommended conventions for polymorphic components.
* Simplifies the markup structure by reducing unnecessary nesting across multiple views.
* The `as` prop is restricted to semantic container tags (`div`, `section`, `article`, etc.) to ensure consistent use aligned with the component’s role as a layout container. You can see all available tags here: [https://github.com/coderdiaz-studio/cvfolio/blob/6877032ae38fb9ca1d660a5b1b859f42e776f281/src/components/Container.astro#L3](https://github.com/coderdiaz-studio/cvfolio/blob/6877032ae38fb9ca1d660a5b1b859f42e776f281/src/components/Container.astro#L3)
* The `main` tag is intentionally excluded because it is already used in the `BaseLayout.astro` component to wrap the entire page, preventing redundant markup.